### PR TITLE
Deployment updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env.*
+node_modules

--- a/django/Dockerfile
+++ b/django/Dockerfile
@@ -10,7 +10,7 @@ ENV PYTHONUNBUFFERED 1
 
 # install psycopg2 dependencies
 RUN apt-get update && apt-get install -y \
-  netcat \
+  netcat-traditional \
   binutils \
   libproj-dev \
   gdal-bin \

--- a/quasar/Dockerfile
+++ b/quasar/Dockerfile
@@ -1,5 +1,5 @@
 # base image
-FROM node:12.2.0-alpine
+FROM node:12.3.1-alpine
 
 # set working directory
 WORKDIR /app
@@ -9,8 +9,8 @@ ENV PATH /app/node_modules/.bin:$PATH
 
 # install and cache app dependencies
 COPY package.json /app/package.json
-RUN yarn install
-RUN yarn global add @quasar/cli
+RUN yarn install --frozen-lockfile
+RUN yarn global add @quasar/cli@1.2.2
 
 # start app
 CMD ["quasar", "dev"]

--- a/quasar/Dockerfile.prod
+++ b/quasar/Dockerfile.prod
@@ -1,10 +1,10 @@
 # build environment
-FROM node:12.2.0-alpine as build
+FROM node:12.3.1-alpine as build
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
 COPY package.json /app/package.json
-RUN yarn install --silent
-RUN yarn global add @quasar/cli
+RUN yarn install --silent --frozen-lockfile
+RUN yarn global add @quasar/cli@1.2.2
 COPY . /app
 RUN quasar build
 


### PR DESCRIPTION
This PR addresses some deployment issues:

1. `django/Dockerfile`
    - switch `netcat` to `netcat-traditional`
2. `.gitignore` file
    - created
3. `quasar/Dockerfile` & `quasar/Dockerfile.prod`:
    - bump Node from 12.2.0 to 12.3.1 (still very out-of-date still :sweat_smile:, but caught up to latest v12 patches at least)
    - install versions defined in yarn lockfile
    - fix specific `@quasar/cli` version (1.2.2) that plays nicely with Node 12.3.1